### PR TITLE
feat: Add API endpoint to get today's glucose readings

### DIFF
--- a/src/modules/glucose/glucose.controller.ts
+++ b/src/modules/glucose/glucose.controller.ts
@@ -1,7 +1,7 @@
 import Elysia, { t } from "elysia"
 import { verifyJWT } from "../auth/auth.service"
 import { getBearerToken } from "../../utils/getBearerToken"
-import { getTodayGlucoseSummary } from "./glucose.service"
+import { getTodayGlucoseSummary, getTodayGlucoseReadings } from "./glucose.service"
 
 export const glucoseRouter = new Elysia({ prefix: '/glucose' })
   .get('/summary/today', 
@@ -31,6 +31,38 @@ export const glucoseRouter = new Elysia({ prefix: '/glucose' })
         }
       } catch (error) {
         console.error('Error getting glucose summary:', error)
+        set.status = 500
+        return { error: 'Internal server error' }
+      }
+    }
+  )
+  .get('/today',
+    async ({ headers, set }) => {
+      try {
+        // Get and verify JWT token
+        const token = getBearerToken(headers.authorization)
+        if (!token) {
+          set.status = 401
+          return { error: 'Authorization token required' }
+        }
+
+        const decoded = await verifyJWT(token)
+        if (!decoded) {
+          set.status = 401
+          return { error: 'Invalid or expired token' }
+        }
+
+        const lineUserId = decoded.lineUserId
+
+        // Get today's glucose readings
+        const readings = await getTodayGlucoseReadings(lineUserId)
+
+        return {
+          success: true,
+          data: readings
+        }
+      } catch (error) {
+        console.error('Error getting glucose readings:', error)
         set.status = 500
         return { error: 'Internal server error' }
       }


### PR DESCRIPTION
This commit introduces a new API endpoint `GET /glucose/today`.

- A new service function `getTodayGlucoseReadings` is added to fetch all of your glucose logs for the current day.
- The function formats the data into an array of objects, each containing the glucose value, the meal period, the recording time, and a status (LOW, NORMAL, HIGH) calculated based on your settings.
- A new route is added to the glucose controller to expose this functionality, protected by JWT authentication.